### PR TITLE
feat: add methods and functions doc comment rules

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -7,3 +7,5 @@ services:
 rules:
     - Oneserv\PHPStan\Rules\Classes\ClassDocumentationIsRequiredRule
     - Oneserv\PHPStan\Rules\Classes\ClassNameMustBeFirstInClassDocumentationRule
+    - Oneserv\PHPStan\Rules\Methods\MethodDocumentationIsRequiredRule
+    - Oneserv\PHPStan\Rules\Functions\FunctionDocumentationIsRequiredRule

--- a/rules_overview.md
+++ b/rules_overview.md
@@ -67,3 +67,61 @@ class SomeClass
     ...
 }
 ```
+
+## FunctionDocumentationIsRequiredRule
+
+**Rule:** A documentation MUST be provided for functions.\
+**Error text:** Function %s has no/an empty doc comment.\
+**Class:**
+[`Oneserv\PHPStan\Rules\Functions\FunctionDocumentationIsRequiredRule`](src/Oneserv/PHPStan/Rules/Functions/FunctionDocumentationIsRequiredRule.php)
+
+### Invalid :x:
+
+```php
+function someFunction() {
+
+}
+```
+
+### Valid :white_check_mark:
+
+```php
+/**
+ * Some documentation.
+ */
+ function someFunction() {
+ 
+ }
+```
+
+## MethodDocumentationIsRequiredRule
+
+**Rule:** A documentation MUST be provided for methods.\
+**Error text:** Method %s has no/an empty doc comment.\
+**Class:**
+[`Oneserv\PHPStan\Rules\Methods\MethodDocumentationIsRequiredRule`](src/Oneserv/PHPStan/Rules/Methods/MethodDocumentationIsRequiredRule.php)
+
+### Invalid :x:
+
+```php
+class SomeClass
+{
+    function someFunction() {
+    
+    }
+}
+```
+
+### Valid :white_check_mark:
+
+```php
+class SomeClass
+{
+    /**
+     * Some documentation.
+     */
+     function someFunction() {
+    
+    }
+}
+```

--- a/src/Oneserv/PHPStan/Rules/Functions/FunctionDocumentationIsRequiredRule.php
+++ b/src/Oneserv/PHPStan/Rules/Functions/FunctionDocumentationIsRequiredRule.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Oneserv\PHPStan\Rules\Classes;
+namespace Oneserv\PHPStan\Rules\Functions;
 
-use Oneserv\PHPStan\Services\ClassHelper;
 use Oneserv\PHPStan\Services\DocCommentHelper;
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
@@ -16,26 +15,22 @@ use Safe\Exceptions\StringsException;
 use function Safe\sprintf;
 
 /**
- * Class ClassDocumentationIsRequiredRule
+ * Class FunctionDocumentationIsRequiredRule
  *
- * @see \Tests\Oneserv\PHPStan\Rules\Classes\ClassDocumentationIsRequiredRuleTest
- * @implements Rule<Class_>
+ * @implements Rule<Function_>
+ * @see \Tests\Oneserv\PHPStan\Rules\Functions\FunctionDocumentationIsRequiredRuleTest
  */
-final class ClassDocumentationIsRequiredRule implements Rule
+final class FunctionDocumentationIsRequiredRule implements Rule
 {
-    private ClassHelper $classHelper;
-
     private DocCommentHelper $docCommentHelper;
 
     /**
-     * ClassDocumentationIsRequiredRule constructor.
+     * FunctionDocumentationIsRequiredRule constructor.
      *
-     * @param ClassHelper $classHelper
      * @param DocCommentHelper $docCommentHelper
      */
-    public function __construct(ClassHelper $classHelper, DocCommentHelper $docCommentHelper)
+    public function __construct(DocCommentHelper $docCommentHelper)
     {
-        $this->classHelper = $classHelper;
         $this->docCommentHelper = $docCommentHelper;
     }
 
@@ -44,7 +39,7 @@ final class ClassDocumentationIsRequiredRule implements Rule
      */
     public function getNodeType(): string
     {
-        return Class_::class;
+        return Function_::class;
     }
 
     /**
@@ -53,24 +48,15 @@ final class ClassDocumentationIsRequiredRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        /** @var Class_ $node */
-        if (!$this->classHelper->shouldClassBeAnalysed($node)) {
-            return [];
-        }
-
-        if ($node->name === null) {
-            throw new ShouldNotHappenException();
-        }
-
+        /** @var Function_ $node */
         $docComment = (string)$node->getDocComment();
         $docComment = $this->docCommentHelper->removeCommentDelimiters($docComment);
         $docComment = $this->docCommentHelper->cleanUpDocComment($docComment);
-
         if ($docComment === '') {
             try {
                 return [
                     sprintf(
-                        'Class %s has no/an empty doc comment.',
+                        'Function %s has no/an empty doc comment.',
                         $node->name->name
                     ),
                 ];

--- a/src/Oneserv/PHPStan/Rules/Methods/MethodDocumentationIsRequiredRule.php
+++ b/src/Oneserv/PHPStan/Rules/Methods/MethodDocumentationIsRequiredRule.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Oneserv\PHPStan\Rules\Classes;
+namespace Oneserv\PHPStan\Rules\Methods;
 
-use Oneserv\PHPStan\Services\ClassHelper;
 use Oneserv\PHPStan\Services\DocCommentHelper;
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
@@ -16,26 +15,22 @@ use Safe\Exceptions\StringsException;
 use function Safe\sprintf;
 
 /**
- * Class ClassDocumentationIsRequiredRule
+ * Class MethodDocumentationIsRequiredRule
  *
- * @see \Tests\Oneserv\PHPStan\Rules\Classes\ClassDocumentationIsRequiredRuleTest
- * @implements Rule<Class_>
+ * @implements Rule<ClassMethod>
+ * @see \Tests\Oneserv\PHPStan\Rules\Methods\MethodDocumentationIsRequiredRuleTest
  */
-final class ClassDocumentationIsRequiredRule implements Rule
+final class MethodDocumentationIsRequiredRule implements Rule
 {
-    private ClassHelper $classHelper;
-
     private DocCommentHelper $docCommentHelper;
 
     /**
-     * ClassDocumentationIsRequiredRule constructor.
+     * MethodDocumentationIsRequiredRule constructor.
      *
-     * @param ClassHelper $classHelper
      * @param DocCommentHelper $docCommentHelper
      */
-    public function __construct(ClassHelper $classHelper, DocCommentHelper $docCommentHelper)
+    public function __construct(DocCommentHelper $docCommentHelper)
     {
-        $this->classHelper = $classHelper;
         $this->docCommentHelper = $docCommentHelper;
     }
 
@@ -44,7 +39,7 @@ final class ClassDocumentationIsRequiredRule implements Rule
      */
     public function getNodeType(): string
     {
-        return Class_::class;
+        return ClassMethod::class;
     }
 
     /**
@@ -53,24 +48,15 @@ final class ClassDocumentationIsRequiredRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        /** @var Class_ $node */
-        if (!$this->classHelper->shouldClassBeAnalysed($node)) {
-            return [];
-        }
-
-        if ($node->name === null) {
-            throw new ShouldNotHappenException();
-        }
-
+        /** @var ClassMethod $node */
         $docComment = (string)$node->getDocComment();
         $docComment = $this->docCommentHelper->removeCommentDelimiters($docComment);
         $docComment = $this->docCommentHelper->cleanUpDocComment($docComment);
-
         if ($docComment === '') {
             try {
                 return [
                     sprintf(
-                        'Class %s has no/an empty doc comment.',
+                        'Method %s has no/an empty doc comment.',
                         $node->name->name
                     ),
                 ];

--- a/src/Oneserv/PHPStan/Services/DocCommentHelper.php
+++ b/src/Oneserv/PHPStan/Services/DocCommentHelper.php
@@ -35,4 +35,15 @@ final class DocCommentHelper
             );
         }
     }
+
+    /**
+     * @param string $docComment
+     * @return string
+     */
+    public function removeCommentDelimiters(string $docComment): string
+    {
+        $docComment = str_replace('/**', '', $docComment);
+        $docComment = str_replace('*/', '', $docComment);
+        return str_replace('*', '', $docComment);
+    }
 }

--- a/tests/Oneserv/PHPStan/Rules/Functions/FunctionDocumentationIsRequiredRuleTest.php
+++ b/tests/Oneserv/PHPStan/Rules/Functions/FunctionDocumentationIsRequiredRuleTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Oneserv\PHPStan\Rules\Functions;
+
+use Oneserv\PHPStan\Rules\Functions\FunctionDocumentationIsRequiredRule;
+use Oneserv\PHPStan\Services\DocCommentHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Class FunctionDocumentationIsRequiredRuleTest
+ *
+ * @see FunctionDocumentationIsRequiredRule
+ * @extends RuleTestCase<FunctionDocumentationIsRequiredRule>
+ */
+final class FunctionDocumentationIsRequiredRuleTest extends RuleTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getRule(): Rule
+    {
+        return new FunctionDocumentationIsRequiredRule(new DocCommentHelper());
+    }
+
+    /**
+     * @see FunctionDocumentationIsRequiredRule::processNode()
+     */
+    public function testProcessNodeShouldPassWithValidDocComment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/FunctionWithValidDocComment.php'],
+            []
+        );
+    }
+
+    /**
+     * @see FunctionDocumentationIsRequiredRule::processNode()
+     */
+    public function testProcessNodeShouldFailPassWithEmptyDocComment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/FunctionWithEmptyDocComment.php'],
+            [
+                [
+                    'Function test has no/an empty doc comment.',
+                    05,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Oneserv/PHPStan/Rules/Functions/data/FunctionWithEmptyDocComment.php
+++ b/tests/Oneserv/PHPStan/Rules/Functions/data/FunctionWithEmptyDocComment.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+function test()
+{
+}

--- a/tests/Oneserv/PHPStan/Rules/Functions/data/FunctionWithValidDocComment.php
+++ b/tests/Oneserv/PHPStan/Rules/Functions/data/FunctionWithValidDocComment.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Valid
+ */
+function test()
+{
+}

--- a/tests/Oneserv/PHPStan/Rules/Methods/MethodDocumentationIsRequiredRuleTest.php
+++ b/tests/Oneserv/PHPStan/Rules/Methods/MethodDocumentationIsRequiredRuleTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Oneserv\PHPStan\Rules\Methods;
+
+use Oneserv\PHPStan\Rules\Methods\MethodDocumentationIsRequiredRule;
+use Oneserv\PHPStan\Services\DocCommentHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Class MethodDocumentationIsRequiredRuleTest
+ *
+ * @extends RuleTestCase<MethodDocumentationIsRequiredRule>
+ * @see MethodDocumentationIsRequiredRule
+ */
+final class MethodDocumentationIsRequiredRuleTest extends RuleTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getRule(): Rule
+    {
+        return new MethodDocumentationIsRequiredRule(new DocCommentHelper());
+    }
+
+    /**
+     * @see MethodDocumentationIsRequiredRule::processNode()
+     */
+    public function testProcessNodeShouldPassWithValidDocComment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/MethodWithValidDocComment.php'],
+            []
+        );
+    }
+
+    /**
+     * @see MethodDocumentationIsRequiredRule::processNode()
+     */
+    public function testProcessNodeShouldFailPassWithEmptyDocComment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/MethodWithEmptyDocComment.php'],
+            [
+                [
+                    'Method test has no/an empty doc comment.',
+                    15,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @see MethodDocumentationIsRequiredRule::processNode()
+     */
+    public function testProcessNodeShouldFailPassWithoutDocComment(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/MethodWithoutDocComment.php'],
+            [
+                [
+                    'Method test has no/an empty doc comment.',
+                    12,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/Oneserv/PHPStan/Rules/Methods/data/MethodWithEmptyDocComment.php
+++ b/tests/Oneserv/PHPStan/Rules/Methods/data/MethodWithEmptyDocComment.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Oneserv\PHPStan\Rules\Methods\data;
+
+/**
+ * Class MethodWithEmptyDocComment
+ */
+class MethodWithEmptyDocComment
+{
+    /**
+     *
+     */
+    public function test()
+    {
+    }
+}

--- a/tests/Oneserv/PHPStan/Rules/Methods/data/MethodWithValidDocComment.php
+++ b/tests/Oneserv/PHPStan/Rules/Methods/data/MethodWithValidDocComment.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Oneserv\PHPStan\Rules\Methods\data;
+
+/**
+ * Class MethodWithValidDocComment
+ */
+class MethodWithValidDocComment
+{
+    /**
+     * Valid
+     */
+    public function test()
+    {
+    }
+}

--- a/tests/Oneserv/PHPStan/Rules/Methods/data/MethodWithoutDocComment.php
+++ b/tests/Oneserv/PHPStan/Rules/Methods/data/MethodWithoutDocComment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Oneserv\PHPStan\Rules\Methods\data;
+
+/**
+ * Class MethodWithoutDocComment
+ */
+class MethodWithoutDocComment
+{
+    public function test()
+    {
+    }
+}

--- a/tests/Oneserv/PHPStan/Services/DocCommentHelperTest.php
+++ b/tests/Oneserv/PHPStan/Services/DocCommentHelperTest.php
@@ -44,4 +44,25 @@ final class DocCommentHelperTest extends TestCase
             )
         );
     }
+
+    /**
+     * @see DocCommentHelper::removeCommentDelimiters()
+     */
+    public function testRemoveCommentDelimitersShouldReturnCleanDocComment(): void
+    {
+        self::assertSame(
+            '
+             test 123
+            
+             @see Class
+            ',
+            $this->docCommentHelper->removeCommentDelimiters(
+                '/**
+            * test 123
+            *
+            * @see Class
+            */'
+            )
+        );
+    }
 }


### PR DESCRIPTION
Adds rules to force methods and functions doc comments to be not empty.